### PR TITLE
feat: add cloudflare turnstile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
+        "@marsidev/react-turnstile": "^1.1.0",
         "@prisma/client": "^6.5.0",
         "@radix-ui/react-label": "^2.1.4",
         "@radix-ui/react-slot": "^1.2.0",
@@ -1048,6 +1049,16 @@
       "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
       "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
       "license": "MIT"
+    },
+    "node_modules/@marsidev/react-turnstile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@marsidev/react-turnstile/-/react-turnstile-1.1.0.tgz",
+      "integrity": "sha512-X7bP9ZYutDd+E+klPYF+/BJHqEyyVkN4KKmZcNRr84zs3DcMoftlMAuoKqNSnqg0HE7NQ1844+TLFSJoztCdSA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.0.0 || ^19.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0"
+      }
     },
     "node_modules/@next/env": {
       "version": "15.2.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
+    "@marsidev/react-turnstile": "^1.1.0",
     "@prisma/client": "^6.5.0",
     "@radix-ui/react-label": "^2.1.4",
     "@radix-ui/react-slot": "^1.2.0",

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -9,6 +9,7 @@ import {
 	FormLabel,
 	FormMessage,
 } from '@/components/ui/form'
+import { Turnstile } from '@marsidev/react-turnstile'
 import type { z } from 'zod'
 import { loginFormSchema } from '@/lib/schemas/auth.schemas'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -117,6 +118,26 @@ export function Form() {
 										</Link>
 									</div>
 								</div>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={form.control}
+					name="captcha"
+					render={({ field }) => (
+						<FormItem>
+							<FormControl>
+								<Turnstile
+									siteKey="1x00000000000000000000AA" // Test site key (always pass)
+									options={{
+										action: 'submit-form',
+										theme: 'light',
+										language: 'pt',
+										size: 'flexible',
+									}}
+								/>
 							</FormControl>
 							<FormMessage />
 						</FormItem>

--- a/src/components/auth/register-form.tsx
+++ b/src/components/auth/register-form.tsx
@@ -3,6 +3,7 @@
 import { registerFormSchema } from '@/lib/schemas/auth.schemas'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
+import { Turnstile } from '@marsidev/react-turnstile'
 import type { z } from 'zod'
 import {
 	Form as FormComponent,
@@ -153,6 +154,26 @@ export function RegisterForm() {
 								<div className="contents">
 									<PasswordInput {...field} placeholder="********" />
 								</div>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={form.control}
+					name="captcha"
+					render={({ field }) => (
+						<FormItem>
+							<FormControl>
+								<Turnstile
+									siteKey="1x00000000000000000000AA" // Test site key (always pass)
+									options={{
+										action: 'submit-form',
+										theme: 'light',
+										language: 'pt',
+										size: 'flexible',
+									}}
+								/>
 							</FormControl>
 							<FormMessage />
 						</FormItem>

--- a/src/lib/schemas/auth.schemas.ts
+++ b/src/lib/schemas/auth.schemas.ts
@@ -5,6 +5,7 @@ export const loginFormSchema = z.object({
 	password: z
 		.string()
 		.min(6, { message: 'Senha deve ter pelo menos 6 caracteres' }),
+	captcha: z.any(),
 })
 
 export const registerFormSchema = z.object({
@@ -17,4 +18,5 @@ export const registerFormSchema = z.object({
 	confirmPassword: z
 		.string()
 		.min(6, { message: 'Senha deve ter pelo menos 6 caracteres' }),
+	captcha: z.any(),
 })


### PR DESCRIPTION
This pull request introduces CAPTCHA validation to the login and registration forms using the Turnstile library. The changes include adding the Turnstile component to the forms, updating the schemas to include a `captcha` field, and adding the required library dependency.

### Integration of CAPTCHA functionality:

* Added `@marsidev/react-turnstile` as a dependency in `package.json` to integrate Turnstile CAPTCHA.
* Imported the `Turnstile` component from `@marsidev/react-turnstile` in `src/components/auth/login-form.tsx` and `src/components/auth/register-form.tsx`. [[1]](diffhunk://#diff-5db90a9bccd670f2a2598f535c39af7ac923e59a800d6929f76783017be265e8R12) [[2]](diffhunk://#diff-4a77ecf3a40e85920a3e701b88ae86359e4ba70e6bf5c49f4403edf682a56a4eR6)
* Updated the login form to include a `FormField` for CAPTCHA, rendering the `Turnstile` component with predefined options such as `siteKey`, `theme`, and `language`.
* Updated the registration form similarly to include a CAPTCHA field using the `Turnstile` component.

### Schema updates:

* Modified `loginFormSchema` and `registerFormSchema` in `src/lib/schemas/auth.schemas.ts` to include a new `captcha` field of type `z.any()`. [[1]](diffhunk://#diff-58ff54835dd6cdbf32d49a7304c7be0644c8207a3f67568283a1ad2e4226895bR8) [[2]](diffhunk://#diff-58ff54835dd6cdbf32d49a7304c7be0644c8207a3f67568283a1ad2e4226895bR21)