### PR TITLE
feat: add profile dialog modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@marsidev/react-turnstile": "^1.1.0",
         "@prisma/client": "^6.5.0",
         "@radix-ui/react-avatar": "^1.1.7",
+        "@radix-ui/react-dialog": "^1.1.11",
         "@radix-ui/react-dropdown-menu": "^2.1.12",
         "@radix-ui/react-label": "^2.1.4",
         "@radix-ui/react-slot": "^1.2.0",
@@ -1504,6 +1505,41 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.11.tgz",
+      "integrity": "sha512-yI7S1ipkP5/+99qhSI6nthfo/tR6bL6Zgxi/+1UO6qPa6UeM6nlafWcQ65vB4rU2XjgjMfMhI3k9Y5MztA62VQ==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.7",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.4",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.6",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.0",
+        "@radix-ui/react-slot": "1.2.0",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@marsidev/react-turnstile": "^1.1.0",
     "@prisma/client": "^6.5.0",
     "@radix-ui/react-avatar": "^1.1.7",
+    "@radix-ui/react-dialog": "^1.1.11",
     "@radix-ui/react-dropdown-menu": "^2.1.12",
     "@radix-ui/react-label": "^2.1.4",
     "@radix-ui/react-slot": "^1.2.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { Navbar } from '@/components/navbar'
+import { ProfileDialog } from '@/components/profile-dialog'
 
 export default function Home() {
 	return (
@@ -6,6 +7,8 @@ export default function Home() {
 			<Navbar />
 
 			<h1>Hello World</h1>
+
+			<ProfileDialog />
 		</>
 	)
 }

--- a/src/components/avatar-dropdown.tsx
+++ b/src/components/avatar-dropdown.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useState } from 'react'
 import { LogOut, User } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
 import {
@@ -8,28 +11,37 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from './ui/dropdown-menu'
+import { ProfileDialog } from './profile-dialog'
 
 export function AvatarDropdown() {
+	const [isDialogOpen, setIsDialogOpen] = useState(false)
+
 	return (
-		<DropdownMenu>
-			<DropdownMenuTrigger>
-				<Avatar>
-					<AvatarImage src="https://github.com/gbrasil720.png" />
-					<AvatarFallback>GB</AvatarFallback>
-				</Avatar>
-			</DropdownMenuTrigger>
-			<DropdownMenuContent className="mr-4 p-2">
-				<DropdownMenuLabel>Minha conta</DropdownMenuLabel>
-				<DropdownMenuSeparator />
-				<DropdownMenuItem className="flex items-center gap-4 cursor-pointer">
-					<User />
-					<span className="text-sm">Perfil</span>
-				</DropdownMenuItem>
-				<DropdownMenuItem className="flex items-center gap-4 cursor-pointer">
-					<LogOut className="text-destructive" />
-					<span className="text-sm text-destructive">Sair</span>
-				</DropdownMenuItem>
-			</DropdownMenuContent>
-		</DropdownMenu>
+		<>
+			<DropdownMenu>
+				<DropdownMenuTrigger className="cursor-pointer">
+					<Avatar>
+						<AvatarImage src="https://github.com/gbrasil720.png" />
+						<AvatarFallback>GB</AvatarFallback>
+					</Avatar>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent className="mr-4 p-2">
+					<DropdownMenuLabel>Minha conta</DropdownMenuLabel>
+					<DropdownMenuSeparator />
+					<DropdownMenuItem
+						className="flex items-center gap-4 cursor-pointer"
+						onClick={() => setIsDialogOpen(true)}
+					>
+						<User />
+						<span className="text-sm">Perfil</span>
+					</DropdownMenuItem>
+					<DropdownMenuItem className="flex items-center gap-4 cursor-pointer">
+						<LogOut className="text-destructive" />
+						<span className="text-sm text-destructive">Sair</span>
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+			<ProfileDialog open={isDialogOpen} onOpenChange={setIsDialogOpen} />
+		</>
 	)
 }

--- a/src/components/profile-dialog.tsx
+++ b/src/components/profile-dialog.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { Dialog, DialogContent, DialogFooter, DialogTitle } from './ui/dialog'
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
+import { NameInput } from './auth/name-input'
+import { EmailInput } from './auth/email-input'
+import { PasswordInput } from './auth/password-input'
+import { Button } from './ui/button'
+
+type ProfileDialogProps = {
+	open?: boolean
+	onOpenChange?: (open: boolean) => void
+}
+
+export function ProfileDialog({ open, onOpenChange }: ProfileDialogProps) {
+	return (
+		<Dialog onOpenChange={onOpenChange} open={open}>
+			<DialogContent className="">
+				<DialogTitle>Perfil</DialogTitle>
+				<div className="flex items-center justify-between">
+					<div className="flex items-center flex-col gap-2">
+						<Avatar className="size-36">
+							<AvatarImage src="https://github.com/gbrasil720.png" />
+							<AvatarFallback>GB</AvatarFallback>
+						</Avatar>
+						<p>Editar</p>
+					</div>
+					<div className="flex flex-col items-center gap-5">
+						<NameInput disabled className="w-64" />
+						<EmailInput disabled className="w-64" />
+						<PasswordInput disabled placeholder="********" className="w-64" />
+					</div>
+				</div>
+				<DialogFooter className="mt-16">
+					<Button
+						variant="outline"
+						className="px-6 rounded-sm cursor-pointer"
+						onClick={() => onOpenChange?.(false)}
+					>
+						Fechar
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+          <XIcon />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}


### PR DESCRIPTION
This pull request introduces a new `ProfileDialog` component for managing user profile interactions and integrates it into the application. Key changes include the addition of the `ProfileDialog` component, updates to the `AvatarDropdown` component to trigger the dialog, and the creation of a reusable `Dialog` component using Radix UI. Below is a breakdown of the most important changes:

### Profile Dialog Implementation:
* Added a new `ProfileDialog` component in `src/components/profile-dialog.tsx` that displays user profile information (e.g., avatar, name, email, password) within a modal dialog. It uses Radix UI's dialog primitives and includes inputs for profile details, though they are currently disabled.

### Avatar Dropdown Integration:
* Updated the `AvatarDropdown` component in `src/components/avatar-dropdown.tsx` to include a button that opens the `ProfileDialog` when clicked. This involves adding state management for dialog visibility and passing the `open` and `onOpenChange` props to the `ProfileDialog`. [[1]](diffhunk://#diff-8659a79c644ec75d6a4d79dfd7c0b5a55042ea353dcc61d07c84f236d409fb00R14-R22) [[2]](diffhunk://#diff-8659a79c644ec75d6a4d79dfd7c0b5a55042ea353dcc61d07c84f236d409fb00L24-R34) [[3]](diffhunk://#diff-8659a79c644ec75d6a4d79dfd7c0b5a55042ea353dcc61d07c84f236d409fb00R44-R45)

### Reusable Dialog Component:
* Created a reusable `Dialog` component in `src/components/ui/dialog.tsx` using Radix UI's dialog primitives. This component includes subcomponents such as `DialogContent`, `DialogTitle`, and `DialogFooter`, allowing for consistent modal dialog styling and behavior throughout the app.

### Dependency Addition:
* Added the `@radix-ui/react-dialog` package to `package.json` to enable the implementation of the dialog functionality.

### Application Integration:
* Integrated the `ProfileDialog` into the `Home` page by importing and rendering it in `src/app/page.tsx`, ensuring it is available for user interaction.