### PR TITLE
feat: update user image dialog

### DIFF
--- a/src/components/edit-user-image-dialog.tsx
+++ b/src/components/edit-user-image-dialog.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { GradientButton } from './gradient-button'
+import { useState } from 'react'
+import { authClient } from '@/lib/auth-client'
+import { toast } from 'sonner'
+import { LoaderCircle } from 'lucide-react'
+
+interface EditUserImageDialogProps {
+	onClose: () => void
+	onOpenChange: (open: boolean) => void
+	open: boolean
+}
+
+export function EditUserImageDialog({
+	onClose,
+	onOpenChange,
+	open,
+}: EditUserImageDialogProps) {
+	const [imageInputValue, setImageInputValue] = useState('')
+	const [loading, setLoading] = useState(false)
+
+	async function handleUpdateUserImage() {
+		setLoading(true)
+
+		await authClient.updateUser({
+			image: imageInputValue,
+		})
+
+		setLoading(false)
+
+		toast.success('Imagem atualizada com sucesso!')
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Atualize sua foto</DialogTitle>
+					<DialogDescription>
+						Para atualizar sua foto, cole o link da nova imagem e clique em
+						salvar.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="flex items-center space-x-2">
+					<div className="grid flex-1 gap-2">
+						<Label htmlFor="link" className="sr-only">
+							Link da imagem
+						</Label>
+						<Input
+							id="link"
+							placeholder="https://imagem.com/imagem.png"
+							onChange={(e) => setImageInputValue(e.target.value)}
+							value={imageInputValue}
+						/>
+					</div>
+				</div>
+				<div className="flex items-center justify-between gap-2">
+					<GradientButton
+						variant="filled"
+						className="w-[25%] text-center cursor-pointer"
+						onClick={handleUpdateUserImage}
+						disabled={loading || !imageInputValue}
+						loading={loading}
+					>
+						Salvar
+					</GradientButton>
+					<Button
+						type="button"
+						variant="outline"
+						className="cursor-pointer"
+						onClick={() => onClose()}
+					>
+						Fechar
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/src/components/profile-dialog.tsx
+++ b/src/components/profile-dialog.tsx
@@ -6,6 +6,8 @@ import { Button } from './ui/button'
 import { authClient } from '@/lib/auth-client'
 import { IconInput } from './icon-input'
 import { AtSign, KeyRound, User } from 'lucide-react'
+import { EditUserImageDialog } from './edit-user-image-dialog'
+import { useState } from 'react'
 
 type ProfileDialogProps = {
 	open?: boolean
@@ -13,54 +15,82 @@ type ProfileDialogProps = {
 }
 
 export function ProfileDialog({ open, onOpenChange }: ProfileDialogProps) {
+	const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
+
 	const { data } = authClient.useSession()
 	const session = data
 
+	function openEditDialog() {
+		onOpenChange?.(false)
+		setIsEditDialogOpen(true)
+	}
+
+	function closeEditDialog() {
+		setIsEditDialogOpen(false)
+		onOpenChange?.(true)
+	}
+
 	return (
-		<Dialog onOpenChange={onOpenChange} open={open}>
-			<DialogContent className="">
-				<DialogTitle>Perfil</DialogTitle>
-				<div className="flex items-center justify-between">
-					<div className="flex items-center flex-col gap-2">
-						<Avatar className="size-36">
-							<AvatarImage
-								src={session?.user.image || 'https://github.com/gbrasil720.png'}
+		<>
+			<Dialog onOpenChange={onOpenChange} open={open}>
+				<DialogContent className="">
+					<DialogTitle>Perfil</DialogTitle>
+					<div className="flex items-center justify-between">
+						<div className="flex items-center flex-col gap-2">
+							<Avatar className="size-36">
+								<AvatarImage
+									src={
+										session?.user.image ||
+										'https://upload.wikimedia.org/wikipedia/commons/7/7c/Profile_avatar_placeholder_large.png?20150327203541'
+									}
+								/>
+								<AvatarFallback>GB</AvatarFallback>
+							</Avatar>
+							<Button
+								onClick={() => openEditDialog()}
+								variant="outline"
+								className="cursor-pointer"
+							>
+								Editar
+							</Button>
+						</div>
+						<div className="flex flex-col items-center gap-5">
+							<IconInput
+								LeftIcon={User}
+								disabled
+								className="w-64 text-[2px]"
+								inputValue={session?.user.name || ''}
 							/>
-							<AvatarFallback>GB</AvatarFallback>
-						</Avatar>
-						<p>Editar</p>
+							<IconInput
+								LeftIcon={AtSign}
+								disabled
+								className="w-64 text-[2px]"
+								inputValue={session?.user.email || ''}
+							/>
+							<IconInput
+								LeftIcon={KeyRound}
+								disabled
+								className="w-64"
+								placeholder="*******"
+							/>
+						</div>
 					</div>
-					<div className="flex flex-col items-center gap-5">
-						<IconInput
-							LeftIcon={User}
-							disabled
-							className="w-64 text-[2px]"
-							inputValue={session?.user.name || ''}
-						/>
-						<IconInput
-							LeftIcon={AtSign}
-							disabled
-							className="w-64 text-[2px]"
-							inputValue={session?.user.email || ''}
-						/>
-						<IconInput
-							LeftIcon={KeyRound}
-							disabled
-							className="w-64"
-							placeholder="*******"
-						/>
-					</div>
-				</div>
-				<DialogFooter className="mt-16">
-					<Button
-						variant="outline"
-						className="px-6 rounded-sm cursor-pointer"
-						onClick={() => onOpenChange?.(false)}
-					>
-						Fechar
-					</Button>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+					<DialogFooter className="mt-16">
+						<Button
+							variant="outline"
+							className="px-6 rounded-sm cursor-pointer"
+							onClick={() => onOpenChange?.(false)}
+						>
+							Fechar
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+			<EditUserImageDialog
+				open={isEditDialogOpen}
+				onOpenChange={openEditDialog}
+				onClose={closeEditDialog}
+			/>
+		</>
 	)
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -20,10 +20,11 @@ export const auth = betterAuth({
 	plugins: [
 		openAPI(),
 		admin(),
-		captcha({
-			provider: 'cloudflare-turnstile',
-			secretKey: process.env.TURNSTILE_SECRET_KEY!,
-		}),
+		// DISABLED FOR NOW
+		// captcha({
+		// 	provider: 'cloudflare-turnstile',
+		// 	secretKey: process.env.TURNSTILE_SECRET_KEY!,
+		// }),
 	],
 })
 


### PR DESCRIPTION
This pull request introduces a new `EditUserImageDialog` component to allow users to update their profile image and integrates it into the existing `ProfileDialog` component. Additionally, it temporarily disables the CAPTCHA plugin in the authentication configuration. Below are the most important changes grouped by theme:

### New Feature: Edit User Image Dialog

* Added a new `EditUserImageDialog` component in `src/components/edit-user-image-dialog.tsx`. This component provides a dialog interface for users to update their profile image by entering a URL. It includes input validation, a loading state, and success feedback using a toast notification.

### Integration with Profile Dialog

* Integrated the `EditUserImageDialog` into the `ProfileDialog` component in `src/components/profile-dialog.tsx`. Added a button labeled "Editar" under the user's avatar to open the new dialog.
* Updated the `ProfileDialog` component to manage the open/close state of the `EditUserImageDialog` and pass appropriate handlers for state transitions.

### Authentication Configuration Update

* Temporarily disabled the CAPTCHA plugin in the `auth` configuration in `src/lib/auth.ts` by commenting out the related code. This change is marked as "DISABLED FOR NOW" for future re-enablement.