### PR TITLE
fix: fix order creation status

### DIFF
--- a/src/components/chatbot.tsx
+++ b/src/components/chatbot.tsx
@@ -253,6 +253,8 @@ export function Chatbot() {
 		setInputValue('')
 		setIsTyping(false)
 		inputRef.current?.focus()
+
+		console.log('orderState', orderState)
 	}
 
 	// Typing indicator component
@@ -507,18 +509,16 @@ export function Chatbot() {
 
 						{/* Show order status */}
 						<div className="flex items-center justify-between">
-							<span className="text-xs font-medium text-muted-foreground">
-								Status:
-							</span>
-							<span
-								className={`text-xs px-2 py-1 rounded-full border ${
-									orderState.orderConfirmed
-										? 'bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20'
-										: 'bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20'
-								}`}
-							>
-								{orderState.orderConfirmed ? 'Confirmado' : 'Pendente'}
-							</span>
+							{orderState.orderConfirmed ?? (
+								<>
+									<span className="text-xs font-medium text-muted-foreground">
+										Status:
+									</span>
+									<span className="text-xs px-2 py-1 bg-green-500/10 text-green-600 dark:text-green-400 rounded-full border border-green-500/20">
+										Em preparo
+									</span>
+								</>
+							)}
 						</div>
 					</div>
 				</div>

--- a/src/components/item/item.tsx
+++ b/src/components/item/item.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { Button } from '../ui/button'
+import { Badge } from '../ui/badge'
 import { Card, CardContent, CardFooter } from '../ui/card'
 import { Checkbox } from '../ui/checkbox'
 import { ManageItem } from './manage-item'
@@ -52,7 +53,26 @@ export function Item({
 						Preço: R$ {Number(price).toFixed(2)}
 					</p>
 				</CardContent>
-				<CardFooter className="p-2 pt-0 -mb-4 justify-end">
+				<CardFooter className="p-2 pt-0 -mb-4 flex justify-between items-center">
+					{/* Stock Status Badges - aligned with button */}
+					<div className="flex flex-col gap-1">
+						{available_quantity === 0 && (
+							<Badge
+								variant="destructive"
+								className="text-xs bg-red-500 text-white border-red-600 shadow-sm"
+							>
+								Esgotado
+							</Badge>
+						)}
+						{available_quantity > 0 && available_quantity <= 5 && (
+							<Badge
+								variant="outline"
+								className="text-xs bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-700 shadow-sm"
+							>
+								Estoque Baixo
+							</Badge>
+						)}
+					</div>
 					<Button
 						variant="outline"
 						className="w-28 text-xs py-1 rounded-sm cursor-pointer"

--- a/src/components/order/order-status-badge.tsx
+++ b/src/components/order/order-status-badge.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle, Clock, XCircle } from 'lucide-react'
+import { CheckCircle, ChefHat, Clock, XCircle } from 'lucide-react'
 import { Badge } from '../ui/badge'
 import { cn } from '@/lib/utils'
 
@@ -12,9 +12,9 @@ export function OrderStatusBadge({ status, className }: OrderStatusBadgeProps) {
 
 	switch (status) {
 		case 'PENDING':
-			icon = <Clock className="text-yellow-500" size={16} />
-			statusLabel = <p className="text-yellow-500">Pendente</p>
-			borderColor = 'border-yellow-500'
+			icon = <ChefHat className="text-blue-500" size={16} />
+			statusLabel = <p className="text-blue-500">Em preparo</p>
+			borderColor = 'border-blue-500'
 			break
 		case 'COMPLETED':
 			icon = <CheckCircle className="text-green-500" size={16} />

--- a/src/lib/order.ts
+++ b/src/lib/order.ts
@@ -235,22 +235,6 @@ export class OrderRepository {
 		const currentStatus = order.status
 		console.log(`Current order status before confirmation: ${currentStatus}`)
 
-		// Only update to COMPLETED if not already completed
-		if (currentStatus === 'COMPLETED') {
-			console.log('Order is already completed, only updating payment method')
-			return await prisma.order.update({
-				where: { id: orderId },
-				data: {
-					paymentMethod: paymentMethod,
-				},
-				include: {
-					items: {
-						include: { item: true },
-					},
-				},
-			})
-		}
-
 		// Check inventory availability before confirming
 		for (const orderItem of order.items) {
 			if (orderItem.item && orderItem.quantity > orderItem.item.quantity) {
@@ -277,11 +261,11 @@ export class OrderRepository {
 				}
 			}
 
-			// Set the order as COMPLETED
+			// Keep the order as PENDING but set payment method
 			return await prisma.order.update({
 				where: { id: orderId },
 				data: {
-					status: 'COMPLETED',
+					status: 'PENDING', // Keep as PENDING instead of COMPLETED
 					paymentMethod: paymentMethod,
 				},
 				include: {
@@ -292,7 +276,9 @@ export class OrderRepository {
 			})
 		})
 
-		console.log('Order confirmed and inventory updated successfully')
+		console.log(
+			'Order confirmed with PENDING status and inventory updated successfully'
+		)
 		return result
 	}
 


### PR DESCRIPTION
This pull request introduces several changes to the chatbot's order handling logic, UI components, and backend services. The most significant updates include a shift in order confirmation logic (keeping confirmed orders in `PENDING` status with payment method set), enhancements to the UI for displaying order and item statuses, and adjustments to the backend logic for managing orders.

### Backend Changes (Order Handling Logic):
* Updated order confirmation logic to keep confirmed orders in `PENDING` status with a payment method set instead of marking them as `COMPLETED`. This affects methods in `OrderRepository` and `OrderService`. [[1]](diffhunk://#diff-0dfc4fe9ea386e111ea12064dbf3513f69e0f28c34348607813a7e7f79539341L280-R268) [[2]](diffhunk://#diff-0dfc4fe9ea386e111ea12064dbf3513f69e0f28c34348607813a7e7f79539341L295-R281) [[3]](diffhunk://#diff-460a0576ba2314b410e452575c2c88f683ebdd5ae6181ae87802c4cc1dabd7ddL231-R247) [[4]](diffhunk://#diff-460a0576ba2314b410e452575c2c88f683ebdd5ae6181ae87802c4cc1dabd7ddL342-R362)
* Added logic to handle scenarios where users want to add items to confirmed orders or update payment methods. [[1]](diffhunk://#diff-a9c61396b15721d7fdacc9733abc24eacb137bc915d7080052202b9692d51523R110-R132) [[2]](diffhunk://#diff-460a0576ba2314b410e452575c2c88f683ebdd5ae6181ae87802c4cc1dabd7ddL52-R75)

### UI Changes (Order and Item Status Display):
* Modified the `OrderStatusBadge` to use a `ChefHat` icon and display "Em preparo" for `PENDING` orders instead of "Pendente."
* Enhanced the `Item` component to include badges indicating stock status (`Esgotado` for out-of-stock and `Estoque Baixo` for low stock).

### Miscellaneous Changes:
* Added a debug log to the `Chatbot` component for tracking `orderState`.
* Imported `Badge` in the `Item` component to support stock status display.