### PR TITLE
feat: add payment method to order details

### DIFF
--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -72,6 +72,7 @@ export async function GET(request: NextRequest) {
 			rating: order.rating,
 			feedback: order.feedback,
 			feedbackAt: order.feedbackAt?.toISOString(),
+			paymentMethod: order.paymentMethod,
 		}))
 
 		const hasMore = offset + orders.length < totalOrders

--- a/src/components/order/order-card.tsx
+++ b/src/components/order/order-card.tsx
@@ -23,6 +23,7 @@ interface ActualOrder {
 	rating?: number | null
 	feedback?: string | null
 	feedbackAt?: string | null
+	paymentMethod?: string | null
 }
 
 interface OrderCardProps {
@@ -82,7 +83,6 @@ export function OrderCard({ order }: OrderCardProps) {
 								variant="outline"
 								onClick={() => setIsFeedbackModalOpen(true)}
 								className="flex items-center gap-1 w-full sm:w-auto"
-								size="sm"
 							>
 								<MessageSquare className="w-4 h-4" />
 								{hasFeedback ? 'Editar Avaliação' : 'Avaliar'}

--- a/src/components/order/order-details.tsx
+++ b/src/components/order/order-details.tsx
@@ -33,6 +33,7 @@ interface ActualOrder {
 	rating?: number | null
 	feedback?: string | null
 	feedbackAt?: string | null
+	paymentMethod?: string | null
 }
 
 interface OrderDetailsProps {

--- a/src/components/order/ui/details-items.tsx
+++ b/src/components/order/ui/details-items.tsx
@@ -1,5 +1,5 @@
 import { StarRating } from '@/components/ui/star-rating'
-import { Star } from 'lucide-react'
+import { Star, Wallet } from 'lucide-react'
 
 // Define the actual order structure being used
 interface OrderItem {
@@ -17,11 +17,29 @@ interface ActualOrder {
 	rating?: number | null
 	feedback?: string | null
 	feedbackAt?: string | null
+	paymentMethod?: string | null
 }
 
 interface DetailsItemsProps {
 	component: 'drawer' | 'dialog'
 	order: ActualOrder
+}
+
+function getPaymentMethodLabel(paymentMethod: string | null) {
+	switch (paymentMethod) {
+		case 'CASH':
+			return 'Dinheiro'
+		case 'CREDIT_CARD':
+			return 'Cartão de Crédito'
+		case 'DEBIT_CARD':
+			return 'Cartão de Débito'
+		case 'PIX':
+			return 'PIX'
+		case 'INDEFINIDO':
+			return 'Indefinido'
+		default:
+			return 'Não informado'
+	}
 }
 
 export function DetailsItems({ component, order }: DetailsItemsProps) {
@@ -48,6 +66,21 @@ export function DetailsItems({ component, order }: DetailsItemsProps) {
 					</div>
 				</div>
 			))}
+
+			{/* Payment Method Section */}
+			<div
+				className={`mt-4 p-3 bg-muted/30 rounded-md border ${component === 'drawer' ? 'mb-2' : ''}`}
+			>
+				<div className="flex items-center gap-2">
+					<Wallet className="w-4 h-4 text-muted-foreground" />
+					<div>
+						<p className="text-sm font-medium">Método de Pagamento</p>
+						<p className="text-sm text-muted-foreground">
+							{getPaymentMethodLabel(order.paymentMethod || null)}
+						</p>
+					</div>
+				</div>
+			</div>
 
 			{/* Feedback Section */}
 			{hasFeedback && (


### PR DESCRIPTION
This pull request introduces enhancements to the order-related components and API by adding support for displaying and handling payment methods. The changes include updates to interfaces, the addition of a new utility function for payment method labels, and modifications to the UI for displaying payment method information.

### API Enhancements:
* [`src/app/api/orders/route.ts`](diffhunk://#diff-0ef2277d3ed802b8b6b26332fc366818d1ff7ba1a07bf12fdfe25c76448f3525R75): Added `paymentMethod` to the API response for orders to include payment method details.

### Interface Updates:
* [`src/components/order/order-card.tsx`](diffhunk://#diff-77947f4d7754d28136113990b26d4cca7c603e589964525ea6ba4522faf160ceR26): Updated the `ActualOrder` interface to include an optional `paymentMethod` property.
* [`src/components/order/order-details.tsx`](diffhunk://#diff-44036b83ddef91efb781dd35ebbfb2e8ca9f2a2fcb25458f4be622ee94c546fbR36): Updated the `ActualOrder` interface to include an optional `paymentMethod` property.
* [`src/components/order/ui/details-items.tsx`](diffhunk://#diff-6606a76c56f31574347f2bf7a1358ccfd72568f52ff6a7e66e0532cae089e3e4R20-R44): Updated the `ActualOrder` interface to include an optional `paymentMethod` property.

### UI Enhancements:
* [`src/components/order/ui/details-items.tsx`](diffhunk://#diff-6606a76c56f31574347f2bf7a1358ccfd72568f52ff6a7e66e0532cae089e3e4R20-R44): Added a utility function `getPaymentMethodLabel` to map payment method codes to user-friendly labels. Introduced a new section in the `DetailsItems` component to display payment method information with an icon. [[1]](diffhunk://#diff-6606a76c56f31574347f2bf7a1358ccfd72568f52ff6a7e66e0532cae089e3e4R20-R44) [[2]](diffhunk://#diff-6606a76c56f31574347f2bf7a1358ccfd72568f52ff6a7e66e0532cae089e3e4R70-R84)
* [`src/components/order/ui/details-items.tsx`](diffhunk://#diff-6606a76c56f31574347f2bf7a1358ccfd72568f52ff6a7e66e0532cae089e3e4L2-R2): Imported the `Wallet` icon from `lucide-react` to visually represent payment methods.

### Minor UI Adjustment:
* [`src/components/order/order-card.tsx`](diffhunk://#diff-77947f4d7754d28136113990b26d4cca7c603e589964525ea6ba4522faf160ceL85): Removed the `size="sm"` attribute from the button in the `OrderCard` component for better styling flexibility.