### PR TITLE
feat: users can now cancel their pending orders

### DIFF
--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -1,0 +1,101 @@
+import { betterFetch } from '@better-fetch/fetch'
+import { prisma } from '@/lib/prisma'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import type { Session } from '@/lib/auth'
+
+export async function PATCH(
+	request: NextRequest,
+	{ params }: { params: Promise<{ id: string }> }
+) {
+	try {
+		const { data: session } = await betterFetch<Session>(
+			'/api/auth/get-session',
+			{
+				baseURL: process.env.BETTER_AUTH_URL,
+				headers: {
+					cookie: request.headers.get('cookie') || '',
+				},
+			}
+		)
+
+		if (!session?.user?.id) {
+			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+		}
+
+		const { id: orderId } = await params
+		const body = await request.json()
+		const { action } = body
+
+		// Check if order exists and belongs to the user
+		const order = await prisma.order.findUnique({
+			where: { id: orderId },
+			select: { userId: true, status: true },
+		})
+
+		if (!order) {
+			return NextResponse.json({ error: 'Order not found' }, { status: 404 })
+		}
+
+		if (order.userId !== session.user.id) {
+			return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+		}
+
+		// Only allow canceling PENDING orders
+		if (action === 'cancel') {
+			if (order.status !== 'PENDING') {
+				return NextResponse.json(
+					{ error: 'Only pending orders can be canceled' },
+					{ status: 400 }
+				)
+			}
+
+			// Update the order status to CANCELLED
+			const updatedOrder = await prisma.order.update({
+				where: { id: orderId },
+				data: { status: 'CANCELLED' },
+				include: {
+					items: {
+						include: {
+							item: true,
+						},
+					},
+				},
+			})
+
+			// Transform the response to match the expected format
+			const transformedOrder = {
+				id: updatedOrder.id,
+				status: 'CANCELED', // Convert CANCELLED to CANCELED for frontend
+				date: updatedOrder.createdAt.toLocaleString('pt-BR', {
+					day: '2-digit',
+					month: '2-digit',
+					year: 'numeric',
+					hour: '2-digit',
+					minute: '2-digit',
+					hour12: false,
+				}),
+				total: Number(updatedOrder.totalPrice),
+				item: updatedOrder.items.map((orderItem) => ({
+					name: orderItem.name,
+					price: Number(orderItem.price),
+					quantity: orderItem.quantity,
+				})),
+				rating: updatedOrder.rating,
+				feedback: updatedOrder.feedback,
+				feedbackAt: updatedOrder.feedbackAt?.toISOString(),
+				paymentMethod: updatedOrder.paymentMethod,
+			}
+
+			return NextResponse.json(transformedOrder)
+		}
+
+		return NextResponse.json({ error: 'Invalid action' }, { status: 400 })
+	} catch (error) {
+		console.error('Error updating order:', error)
+		return NextResponse.json(
+			{ error: 'Internal server error' },
+			{ status: 500 }
+		)
+	}
+}

--- a/src/components/confirm-order-cancel-dialog.tsx
+++ b/src/components/confirm-order-cancel-dialog.tsx
@@ -1,11 +1,14 @@
 import { Button } from './ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog'
+import { generateOrderNumber } from '@/lib/utils'
 
 interface ConfirmOrderCancelDialogProps {
 	open: boolean
 	onOpenChange: (open: boolean) => void
 	onClose: () => void
 	deleteOrder: () => void
+	orderId?: string
+	isLoading?: boolean
 }
 
 export function ConfirmOrderCancelDialog({
@@ -13,7 +16,11 @@ export function ConfirmOrderCancelDialog({
 	onOpenChange,
 	onClose,
 	deleteOrder,
+	orderId,
+	isLoading = false,
 }: ConfirmOrderCancelDialogProps) {
+	const orderNumber = orderId ? generateOrderNumber(orderId) : '0001'
+
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent>
@@ -22,21 +29,30 @@ export function ConfirmOrderCancelDialog({
 					Você tem certeza?
 				</DialogHeader>
 				<p className="text-light text-center">
-					Você está prestes a cancelar o Pedido 0001, tem certeza? Essa ação não
-					poderá ser desfeita
+					Você está prestes a cancelar o Pedido #{orderNumber}, tem certeza?
+					Essa ação não poderá ser desfeita
 				</p>
 				<div className="flex justify-between items-center mt-4 px-3">
 					<Button
 						onClick={deleteOrder}
 						variant="outline"
 						className="border-destructive text-destructive hover:bg-destructive hover:text-white cursor-pointer"
+						disabled={isLoading}
 					>
-						Sim, cancelar
+						{isLoading ? (
+							<>
+								<div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin mr-2" />
+								Cancelando...
+							</>
+						) : (
+							'Sim, cancelar'
+						)}
 					</Button>
 					<Button
 						variant="outline"
 						className="cursor-pointer"
 						onClick={onClose}
+						disabled={isLoading}
 					>
 						Fechar
 					</Button>

--- a/src/components/order/order-details.tsx
+++ b/src/components/order/order-details.tsx
@@ -17,6 +17,8 @@ import {
 import { OrderDetailsDrawerFooter } from './ui/details-footer'
 import { DetailsItems } from './ui/details-items'
 import { generateOrderNumber } from '@/lib/utils'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 // Define the actual order structure being used
 interface OrderItem {
 	name: string
@@ -47,6 +49,35 @@ export function OrderDetails({ order }: OrderDetailsProps) {
 	const isMounted = useIsMounted()
 	const mediaQueryResult = useMediaQuery('(min-width: 768px)')
 	const orderNumber = generateOrderNumber(order.id)
+	const queryClient = useQueryClient()
+
+	const cancelOrderMutation = useMutation({
+		mutationFn: async () => {
+			const response = await fetch(`/api/orders/${order.id}`, {
+				method: 'PATCH',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ action: 'cancel' }),
+			})
+
+			if (!response.ok) {
+				throw new Error('Failed to cancel order')
+			}
+
+			return response.json()
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['orders'] })
+			toast.success('Pedido cancelado com sucesso!')
+			setOpen(false)
+			setOpenConfirmation(false)
+		},
+		onError: (error: Error) => {
+			toast.error(`Erro ao cancelar o pedido: ${error.message}`)
+		},
+	})
+
 	useEffect(() => {
 		if (isMounted()) {
 			setIsDesktop(mediaQueryResult)
@@ -58,7 +89,9 @@ export function OrderDetails({ order }: OrderDetailsProps) {
 		setOpen(false)
 	}
 
-	function handleDeleteOrder() {}
+	function handleDeleteOrder() {
+		cancelOrderMutation.mutate()
+	}
 
 	if (!isMounted() || isDesktop === null) {
 		return (
@@ -104,6 +137,8 @@ export function OrderDetails({ order }: OrderDetailsProps) {
 					open={openConfirmation}
 					onClose={() => setOpenConfirmation(false)}
 					deleteOrder={handleDeleteOrder}
+					orderId={order.id}
+					isLoading={cancelOrderMutation.isPending}
 				/>
 			</>
 		)

--- a/src/components/order/ui/details-footer.tsx
+++ b/src/components/order/ui/details-footer.tsx
@@ -15,6 +15,7 @@ interface ActualOrder {
 	rating?: number | null
 	feedback?: string | null
 	feedbackAt?: string | null
+	paymentMethod?: string | null
 }
 
 interface OrderProps {


### PR DESCRIPTION
This pull request implements functionality to cancel orders and integrates it across the backend API and frontend components. The changes include adding a new API route for handling order cancellation, updating the UI components to support cancellation, and improving user feedback during the process.

### Backend API Changes:

* Added a `PATCH` method in `src/app/api/orders/[id]/route.ts` to handle order cancellation. It validates the user's session, checks order ownership and status, and updates the order status to `CANCELLED` if valid. The response is transformed to match frontend requirements. ([src/app/api/orders/[id]/route.tsR1-R101](diffhunk://#diff-23a8ae224e57845dc3abfece2dcc81f13143d44fb1a93bf4b203ae3693d8c257R1-R101))

### Frontend Component Updates:

* Updated `src/components/confirm-order-cancel-dialog.tsx` to display dynamic order numbers, disable buttons during loading, and show a spinner with "Cancelando..." text while the cancellation is in progress. [[1]](diffhunk://#diff-95ab5dadec21b8fabb63aa2dcad9139e1e7a7931095192837c5fef951872058dR3-R23) [[2]](diffhunk://#diff-95ab5dadec21b8fabb63aa2dcad9139e1e7a7931095192837c5fef951872058dL25-R55)
* Enhanced `src/components/order/order-details.tsx` with a mutation using `react-query` to cancel orders via the new API route. Added user feedback with success and error toasts, and integrated the mutation into the confirmation dialog. [[1]](diffhunk://#diff-44036b83ddef91efb781dd35ebbfb2e8ca9f2a2fcb25458f4be622ee94c546fbR20-R21) [[2]](diffhunk://#diff-44036b83ddef91efb781dd35ebbfb2e8ca9f2a2fcb25458f4be622ee94c546fbR52-R80) [[3]](diffhunk://#diff-44036b83ddef91efb781dd35ebbfb2e8ca9f2a2fcb25458f4be622ee94c546fbL61-R94) [[4]](diffhunk://#diff-44036b83ddef91efb781dd35ebbfb2e8ca9f2a2fcb25458f4be622ee94c546fbR140-R141)

### Miscellaneous Updates:

* Added `paymentMethod` as an optional property in the `ActualOrder` interface in `src/components/order/ui/details-footer.tsx`.